### PR TITLE
QueryRoute on payment modal

### DIFF
--- a/components/Receive.js
+++ b/components/Receive.js
@@ -6,6 +6,7 @@ import { setSelectedWallet } from "contexts/modules/wallet";
 import { useEffect, useState } from "react";
 import { useAppSelector } from "hooks";
 import Img from "react-cool-img"
+import useSWR from 'swr';
 import { UI } from "consts";
 import { API_NAMES } from "consts";
 import { getRequest } from "utils/api";
@@ -93,7 +94,16 @@ export const Receive = () => {
 
 const InvoiceForm = ({ onCreateInvoice, currency }) => {
 	const [amount, setAmount] = useState(0);
+	const [satsAmount, setSatsAmount] = useState(0);
 	const [memo, setMemo] = useState("");
+	const { data: newQuote } = useSWR(currency !== "BTC" ? [API_NAMES.QUOTE, currency, "BTC", amount] : null);
+
+	useEffect(() => {
+		if (!newQuote) return
+		if (currency !== "BTC") {
+			setSatsAmount(roundDecimal(amount * Number(newQuote.rate) * 100000000, 2))
+		}
+	}, [newQuote])
 	return (
 		<div>
 			<div className="text-left mt-8">
@@ -103,6 +113,11 @@ const InvoiceForm = ({ onCreateInvoice, currency }) => {
 						<FormatCurrencyInput value={amount} symbol={currency} style={"input-default inline-block w-full border rounded-md border-transparent h-14 bg-gray-700"} onValueChange={(values) => setAmount(values.value)}/>
 					</div>
 				</div>
+				{
+					currency !== "BTC" && (
+						<div>{satsAmount} sats</div>
+					)
+				}
 				<div className="mt-8">
 					Description <span className="text-xs">(optional)</span>
 					<div className="border border-1 border-gray-600 mt-1 rounded-md w-full relative">

--- a/components/SendPayment.js
+++ b/components/SendPayment.js
@@ -200,7 +200,7 @@ const InvoiceForm = ({ invoice, setInvoice, onPayInvoice, currency, balance }) =
 		} catch (err) {
 			setInvoiceValid(false)
 		}
-	}, [invoice, newRoute])
+	}, [invoice])
 
 	useEffect(() => {
 		if (!newQuote) return

--- a/components/SendPayment.js
+++ b/components/SendPayment.js
@@ -349,7 +349,7 @@ const InvoiceForm = ({ invoice, setInvoice, onPayInvoice, currency, balance }) =
 										className="input-default inline-block w-full rounded-md border-transparent h-14 bg-gray-700"
 									/>
 								</div>
-								<div className="mt-2 px-2">Max amount to send: {maxAmountSend*100000000} sats</div>
+								<div className="mt-2 px-2">Max amount to send: {roundDecimal(maxAmountSend*100000000, 2)} sats</div>
 							</div>
 						</div>
 						<div className="grid grid-cols-2 gap-2 mt-2 p-4 font-light">

--- a/components/SendPayment.js
+++ b/components/SendPayment.js
@@ -107,7 +107,7 @@ export const SendPayment = () => {
 							isPaymentComplete ? (
 								<PaymentComplete paymentObj={paymentObj} />
 							) : (
-								<InvoiceForm invoice={invoice} setInvoice={setInvoice} onPayInvoice={onPayInvoice} currency={selectedWallet} balance={balance} />
+								<InvoiceForm invoice={invoice} setInvoice={setInvoice} onPayInvoice={onPayInvoice} currency={selectedWallet} balance={wallets[selectedWallet].balance} />
 							)
 						}
 					</div>
@@ -126,7 +126,6 @@ const InvoiceForm = ({ invoice, setInvoice, onPayInvoice, currency, balance }) =
 	const [maxFeeFiat, setMaxFeeFiat] = useState(0);
 	const [invoiceValid, setInvoiceValid] = useState(false);
 	const [quote, setQuote] = useState(1);
-	const [probe, setProbe] = useState(2);
 	const [hasSufficienFunds, setHasSufficientFunds] = useState(true);
 
 	const [isLnurlWithdrawal, setIsLnurlWithdrawal] = useState(true);
@@ -141,7 +140,7 @@ const InvoiceForm = ({ invoice, setInvoice, onPayInvoice, currency, balance }) =
 	const [bankInfo, selectedWallet] = useAppSelector(state => [state.bank.info, state.wallets.selectedWallet])
 
 	const { data: newQuote } = useSWR(currency !== "BTC" ? [API_NAMES.QUOTE, currency, "BTC", amount] : null);
-	const { data: newProbe } = useSWR(invoice ? [API_NAMES.PROBE, invoice] : null);
+	const { data: newRoute } = useSWR(invoice ? [API_NAMES.QUERY_ROUTE, invoice] : null);
 
 	const btcUnit = defaultLocalStore.cookieGet(CONTEXTS.LOCAL_STORAGE.DISPLAY_BTC_IN);
 
@@ -201,25 +200,29 @@ const InvoiceForm = ({ invoice, setInvoice, onPayInvoice, currency, balance }) =
 		} catch (err) {
 			setInvoiceValid(false)
 		}
-	}, [invoice])
-
-	useEffect(() => {
-		if (!newProbe || !invoice) return
-		const fees_in_sats = newProbe.fees_in_sats;
-		setMaxFee(fees_in_sats);
-		const networkFee = 0.01;
-		if (currency !== "BTC") {
-			setMaxAmountSend(roundDecimal(balance * Number(quote.rate) * (1 - networkFee), 8))
-		} else {
-			setMaxAmountSend(roundDecimal(balance * 100000000 - (balance * 100000000 - fees_in_sats), 2))
-		}
-	}, [invoice, newProbe])
+	}, [invoice, newRoute])
 
 	useEffect(() => {
 		if (!newQuote) return
 		setQuote(newQuote);
 		setFiatAmount(roundDecimal(amount / Number(newQuote.rate), 8))
-	}, [newQuote])
+	}, [newQuote, balance])
+
+	useEffect(() => {
+		if (!invoice || !newRoute) return
+		const fees_in_sats = newRoute.totalFee;
+		setMaxFee(fees_in_sats);
+		if (currency !== "BTC") {
+			if (!newQuote) return
+			let balanceInSats = balance * Number(newQuote.rate) * 100000000;
+			setMaxAmountSend(roundDecimal((balanceInSats - fees_in_sats) / 100000000, 8))
+			let fiatAmountInSats = amount / Number(newQuote.rate) * 100000000
+			setMaxFeeFiat((fiatAmountInSats - fees_in_sats) / 100000000);
+		} else {
+			let balanceInSats = balance * 100000000
+			setMaxAmountSend(roundDecimal((balanceInSats - fees_in_sats) / 100000000, 8))
+		}
+	}, [newQuote, newRoute])
 
 	useEffect(() => {
 		if (currency === "BTC" && balance < amount) {
@@ -258,7 +261,6 @@ const InvoiceForm = ({ invoice, setInvoice, onPayInvoice, currency, balance }) =
 		console.log(bankInfo)
 		console.log(amount)
 		if (!bankInfo || !amount) return
-		setMaxFeeFiat(fiatAmount * Number(bankInfo.lnNetworkMaxFee));
 	}, [amount, bankInfo])
 
 	return (
@@ -347,14 +349,14 @@ const InvoiceForm = ({ invoice, setInvoice, onPayInvoice, currency, balance }) =
 										className="input-default inline-block w-full rounded-md border-transparent h-14 bg-gray-700"
 									/>
 								</div>
-								<div className="mt-2 px-2">Max Amount to send: {maxAmountSend} sats</div>
+								<div className="mt-2 px-2">Max amount to send: {maxAmountSend*100000000} sats</div>
 							</div>
 						</div>
 						<div className="grid grid-cols-2 gap-2 mt-2 p-4 font-light">
 							<div className="text-left w-full">Amount</div>
 							<div className="text-right w-full">
 								<div>
-									{amount*100000000} sats
+									{Math.floor(amount*100000000)} sats
 								</div>
 								{
 									currency !== "BTC" && (
@@ -366,7 +368,7 @@ const InvoiceForm = ({ invoice, setInvoice, onPayInvoice, currency, balance }) =
 							<div className="text-left w-full">Max Fee</div>
 							<div className="text-right w-full">
 								<div>
-									{roundDecimal(maxFee*100000000, 2)} sats
+									{roundDecimal(maxFee, 2)} sats
 								</div>
 								{
 									currency !== "BTC" && (

--- a/consts/api.ts
+++ b/consts/api.ts
@@ -171,9 +171,9 @@ const API: I_API = {
 			stale: API_TIME.NONE,
 			allowNull: true,
 		},
-		PROBE: {
+		QUERY_ROUTE: {
 			route: (payment_request) =>
-				`/probe?payment_request=${payment_request}`,
+				`/query_route?payment_request=${payment_request}`,
 			method: 'get',
 			base: END_POINTS.BACK,
 			stale: API_TIME.SHORTEST,

--- a/consts/api.ts
+++ b/consts/api.ts
@@ -171,6 +171,14 @@ const API: I_API = {
 			stale: API_TIME.NONE,
 			allowNull: true,
 		},
+		PROBE: {
+			route: (payment_request) =>
+				`/probe?payment_request=${payment_request}`,
+			method: 'get',
+			base: END_POINTS.BACK,
+			stale: API_TIME.SHORTEST,
+			allowNull: true,
+		},
 		QUOTE: {
 			route: (fromCurrency, toCurrency, amount) =>
 				`/quote?amount=${amount}&from_currency=${fromCurrency}&to_currency=${toCurrency}`,

--- a/utils/refiners/api.ts
+++ b/utils/refiners/api.ts
@@ -82,6 +82,11 @@ refiner.set(API_NAMES.SWAP, data => {
 	return camelCaseAllKeys(data);
 });
 
+refiner.set(API_NAMES.QUERY_ROUTE, data => {
+	console.log({data: camelCaseAllKeys(data)})
+	return camelCaseAllKeys(data);
+});
+
 refiner.set(API_NAMES.QUOTE, data => {
 	console.log({data: camelCaseAllKeys(data)})
 	return camelCaseAllKeys(data);


### PR DESCRIPTION
This PR adds:
- Bugfixes for sat amounts on `maxSendAmount` and estimated fee
- Bugfixes for an outdated balance being passed to the send payment form
- Querying for routes as soon as the user shows intent to make a payment

Caveats:
- For small amounts (< 5000 sats), the estimate may be too high. In this case, the user will get a refund of the sats that were reserved but not utilized for the payment.